### PR TITLE
Multiple fixes

### DIFF
--- a/CRM/Civirules/Action/MauticWebHookCreateContact.php
+++ b/CRM/Civirules/Action/MauticWebHookCreateContact.php
@@ -27,10 +27,10 @@ class CRM_Civirules_Action_MauticWebHookCreateContact extends CRM_Civirules_Acti
     $contactParams = [
       'contact_type' => 'Individual',
     ];
-    if (!empty($webhook['contact_id'])) {
+    if (!empty($triggerData->getContactId())) {
       if ($updateContact) {
         // Update with the ID.
-        $contactParams['id'] = $webhook['contact_id'];
+        $contactParams['id'] = $triggerData->getContactId();
       }
       else {
         // Skip. Do nothing.
@@ -42,8 +42,8 @@ class CRM_Civirules_Action_MauticWebHookCreateContact extends CRM_Civirules_Acti
     }
 
     // Get the contact data from the webhook.
-    $mauticData = json_decode($webhook['data'], TRUE);
-    $mauticContact = !empty($mauticData['contact']) ? $mauticData['contact'] : $mauticData['lead'];
+    $mauticData = $webhook['data'];
+    $mauticContact = $mauticData['contact'] ?? $mauticData['lead'];
     // If payload is from a subscription change event, copy data to the contact.
     // Then we can let the fieldMapping class handle how this can be converted.
     if ($mauticContact && !empty($mauticData['channel'])) {

--- a/CRM/Civirules/Action/MauticWebHookCreateContact.php
+++ b/CRM/Civirules/Action/MauticWebHookCreateContact.php
@@ -91,8 +91,8 @@ class CRM_Civirules_Action_MauticWebHookCreateContact extends CRM_Civirules_Acti
       CRM_Mautic_Contact_ContactMatch::getContactReferenceFromMautic($mauticContact))) {
         $mautic = CRM_Mautic_Connection::singleton()->newApi('contacts');
         $editParams = [CRM_Mautic_Contact_ContactMatch::MAUTIC_ID_FIELD_ALIAS => $contactId];
-        $mautic->edit($mauticContact->id, $editParams, FALSE);
-        U::checkDebug("Updating Mautic Contact with CiviCRM Contact id", [$mauticContact->id, $editParams]);
+        $mautic->edit($mauticContact['id'], $editParams, FALSE);
+        U::checkDebug("Updating Mautic Contact with CiviCRM Contact id", [$mauticContact['id'], $editParams]);
       }
     }
     catch(Exception $e) {

--- a/CRM/Civirules/Action/MauticWebHookCreateContact.php
+++ b/CRM/Civirules/Action/MauticWebHookCreateContact.php
@@ -60,7 +60,7 @@ class CRM_Civirules_Action_MauticWebHookCreateContact extends CRM_Civirules_Acti
       return;
     }
     // Does the Webhook payload provide only a partial contact eg. from a subscription change trigger event?
-    $isPartialContact = empty($mauticContact->fields);
+    $isPartialContact = empty($mauticContact['fields']);
 
     // Convert from Mautic to Civi contact fields.
     $convertedData = CRM_Mautic_Contact_FieldMapping::convertToCiviContact($mauticContact);
@@ -74,23 +74,25 @@ class CRM_Civirules_Action_MauticWebHookCreateContact extends CRM_Civirules_Acti
     try {
       $contactParams = array_filter($contactParams, function($val) { return !is_null($val);});
       $result = civicrm_api3('Contact', 'create', $contactParams);
-      U::checkDebug('Update contact', $contactParams);
+      U::checkDebug($contactParams['id'] ? 'Update contact' : 'Create contact', $contactParams);
 
+      $contactId = $result['id'];
       // Set the contact id for other rule actions.
-      if (!empty($result['id']) && !$triggerData->getContactId()) {
-        $triggerData->setContactId($result['id']);
+      if (!empty($contactId) && !$triggerData->getContactId()) {
+        $triggerData->setContactId($contactId);
       }
-      $contactId = !empty($result['id']) ? $result['id'] : NULL;
+
       // Update the contact tags.
       if (!$isPartialContact) {
         CRM_Mautic_Contact_FieldMapping::saveMauticTagsToCiviContact($mauticContact, $contactId);
       }
       // Update the Mautic Contact with a reference to the CiviCRM Contact.
-      if (!$isPartialContact && $contactId && $contactId != CRM_Mautic_Contact_ContactMatch::getContactReferenceFromMautic($mauticContact)) {
+      if (!$isPartialContact && $contactId && ($contactId !=
+      CRM_Mautic_Contact_ContactMatch::getContactReferenceFromMautic($mauticContact))) {
         $mautic = CRM_Mautic_Connection::singleton()->newApi('contacts');
         $editParams = [CRM_Mautic_Contact_ContactMatch::MAUTIC_ID_FIELD_ALIAS => $contactId];
         $mautic->edit($mauticContact->id, $editParams, FALSE);
-        U::checkDebug("Updating Mautic Contact  with CiviCRM Contact id", [$mauticContact->id, $editParams]);
+        U::checkDebug("Updating Mautic Contact with CiviCRM Contact id", [$mauticContact->id, $editParams]);
       }
     }
     catch(Exception $e) {

--- a/CRM/Civirules/Condition/MauticContactFieldValue.php
+++ b/CRM/Civirules/Condition/MauticContactFieldValue.php
@@ -38,7 +38,7 @@ class CRM_Civirules_Condition_MauticContactFieldValue extends CRM_Civirules_Cond
     $searchValue = $this->conditionParams[$field_name];
     $webhook = $triggerData->getEntityData('mauticwebhook');
     if ($searchValue && $webhook) {
-      $contact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook);
+      $contact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook['data']);
       if (!empty($contact['fields']['core'][$field_name])) {
         return $contact['fields']['core'][$field_name]['value'] == $searchValue;
       }

--- a/CRM/Civirules/Condition/MauticContactHasTag.php
+++ b/CRM/Civirules/Condition/MauticContactHasTag.php
@@ -34,17 +34,15 @@ class CRM_Civirules_Condition_MauticContactHasTag extends CRM_Civirules_Conditio
    * @access public
    */
   public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData) {
-    $webHook = $triggerData->getEntityData('mauticwebhook');
-    $mauticContact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webHook);
+    $webhook = $triggerData->getEntityData('mauticwebhook');
+    $mauticContact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook['data']);
     if (empty($mauticContact['tags'])) {
       return FALSE;
     }
     $searchTags = $this->getSelectedTags();
     $op = $this->conditionParams['operator'];
     // Normalize to just an array of tag names. We don't match IDs.
-    $contactTags = array_map(function($val) {
-      return $val['tag'];
-    }, $mauticContact['tags']);
+    $contactTags = array_map(function($val) { return $val['tag']; }, $mauticContact['tags']);
     return $op == 'all' ? empty(array_diff($searchTags, $contactTags)) : !empty(array_intersect($searchTags, $contactTags));
   }
 

--- a/CRM/Civirules/Condition/MauticWebHookType.php
+++ b/CRM/Civirules/Condition/MauticWebHookType.php
@@ -38,7 +38,7 @@ class CRM_Civirules_Condition_MauticWebHookType extends CRM_Civirules_Condition 
     $webhook = $triggerData->getEntityData('mauticwebhook');
     $negate = $this->conditionParams['operator'];
     $type = $webhook['webhook_trigger_type'];
-    CRM_Mautic_Utils::checkDebug("Checking for $type against", $this->getSelectedTypes());
+    CRM_Mautic_Utils::checkDebug("Checking for {$type} against", $this->getSelectedTypes());
     $isType = $type && in_array(str_replace('mautic.', '', $type), $this->getSelectedTypes());
     return $negate ? !$isType : $isType;
   }

--- a/CRM/Civirules/Condition/MauticWebHookType.php
+++ b/CRM/Civirules/Condition/MauticWebHookType.php
@@ -37,9 +37,9 @@ class CRM_Civirules_Condition_MauticWebHookType extends CRM_Civirules_Condition 
   public function isConditionValid(CRM_Civirules_TriggerData_TriggerData $triggerData) {
     $webhook = $triggerData->getEntityData('mauticwebhook');
     $negate = $this->conditionParams['operator'];
-    $type = $webhook['webhook_trigger_type'];
+    $type = str_replace('mautic.', '', $webhook['webhook_trigger_type']);
     CRM_Mautic_Utils::checkDebug("Checking for {$type} against", $this->getSelectedTypes());
-    $isType = $type && in_array(str_replace('mautic.', '', $type), $this->getSelectedTypes());
+    $isType = $type && in_array($type, $this->getSelectedTypes());
     return $negate ? !$isType : $isType;
   }
 

--- a/CRM/Civirules/Trigger/MauticWebHook.php
+++ b/CRM/Civirules/Trigger/MauticWebHook.php
@@ -59,8 +59,13 @@ class CRM_Civirules_Trigger_MauticWebHook extends CRM_Civirules_Trigger_Post {
 
     // Set the trigger contact id to the WebHook data.
     $webhook = $triggerData->getEntityData('mauticwebhook');
+    // Retrieve all data for webhook
+    $originalData = $triggerData->getOriginalData();
+    $webhook = array_merge($originalData, $webhook);
+    // Decode webhook data
     $webhook['data'] = json_decode($webhook['data'], TRUE);
     $triggerData->setEntityData('mauticwebhook', $webhook);
+    // Set contact ID from mautic data
     if (!$triggerData->getContactId()) {
       $contact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook['data']);
       $triggerData->setContactId(CRM_Mautic_Contact_FieldMapping::getValue($contact, 'civicrm_contact_id', NULL));

--- a/CRM/Civirules/Trigger/MauticWebHook.php
+++ b/CRM/Civirules/Trigger/MauticWebHook.php
@@ -56,16 +56,14 @@ class CRM_Civirules_Trigger_MauticWebHook extends CRM_Civirules_Trigger_Post {
   public function alterTriggerData(CRM_Civirules_TriggerData_TriggerData &$triggerData) {
     $hook_invoker = CRM_Civirules_Utils_HookInvoker::singleton();
     $hook_invoker->hook_civirules_alterTriggerData($triggerData);
-    // Set the trigger contact id to the WebHook data.
-    // The contact is discovered when the webhook is initially processed.
 
+    // Set the trigger contact id to the WebHook data.
     $webhook = $triggerData->getEntityData('mauticwebhook');
-    $oldData = $triggerData->getOriginalData();
-    $triggerData->setEntityData('mauticwebhook', array_merge($oldData, $webhook));
+    $webhook['data'] = json_decode($webhook['data'], TRUE);
+    $triggerData->setEntityData('mauticwebhook', $webhook);
     if (!$triggerData->getContactId()) {
-      if (!empty($webhook['contact_id'])) {
-        $triggerData->setContactId($webhook['contact_id']);
-      }
+      $contact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook['data']);
+      $triggerData->setContactId(CRM_Mautic_Contact_FieldMapping::getValue($contact, 'civicrm_contact_id', NULL));
     }
   }
 

--- a/CRM/Civirules/Trigger/MauticWebHook.php
+++ b/CRM/Civirules/Trigger/MauticWebHook.php
@@ -49,6 +49,22 @@ class CRM_Civirules_Trigger_MauticWebHook extends CRM_Civirules_Trigger_Post {
   }
 
   /**
+   * Trigger a rule for this trigger
+   *
+   * @param $op
+   * @param $objectName
+   * @param $objectId
+   * @param $objectRef
+   */
+  public function triggerTrigger($op, $objectName, $objectId, $objectRef, $eventID) {
+    $triggerData = $this->getTriggerDataFromPost($op, $objectName, $objectId, $objectRef, $eventID);
+    if (isset($triggerData->getEntityData('mauticwebhook')['civirules_do_not_process'])) {
+      return;
+    }
+    CRM_Civirules_Engine::triggerRule($this, clone $triggerData);
+  }
+
+  /**
    * Alter the trigger data with extra data
    *
    * @param \CRM_Civirules_TriggerData_TriggerData $triggerData
@@ -68,7 +84,7 @@ class CRM_Civirules_Trigger_MauticWebHook extends CRM_Civirules_Trigger_Post {
     // Set contact ID from mautic data
     if (!$triggerData->getContactId()) {
       $contact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook['data']);
-      $triggerData->setContactId(CRM_Mautic_Contact_FieldMapping::getValue($contact, 'civicrm_contact_id', NULL));
+      $triggerData->setContactId(CRM_Mautic_Contact_FieldMapping::lookupMauticValue('civicrm_contact_id', $contact));
     }
   }
 

--- a/CRM/Mautic/APIBatchList.php
+++ b/CRM/Mautic/APIBatchList.php
@@ -5,20 +5,20 @@
  */
 class CRM_Mautic_APIBatchList {
   /**
-   * 
+   *
    * @var int.
    */
   protected $batchSize = 0;
-  
+
   protected $offset = 0;
-  
+
   protected $total = NULL;
-  
+
   protected $context = '';
-  
+
   protected $data = [];
-  
- 
+
+
   /*
    * Parameters for the list call.
    */
@@ -29,19 +29,19 @@ class CRM_Mautic_APIBatchList {
     'publishedOnly' => TRUE,
     'minimal' => FALSE,
   ];
-  
+
   /**
-   * 
+   *
    * @var Mautic\Api\Api
    */
   protected $api = NULL;
-  
+
   public function getAPI() {
     return $this->api;
   }
-  
+
   /**
-   * 
+   *
    * @param string $context
    * @param int $batchSize
    * @param [] $params
@@ -52,7 +52,7 @@ class CRM_Mautic_APIBatchList {
     $this->context = $context;
     $this->params = array_merge($this->params, $params);
   }
-  
+
   public function fetchBatch() {
     $start = $this->offset;
     $limit = $this->batchSize;
@@ -60,7 +60,7 @@ class CRM_Mautic_APIBatchList {
     if (isset($this->total) && $start >= $this->total) {
       return;
     }
-    
+
     $items = $this->api->getList(
         $params['search'],
         $start,
@@ -76,8 +76,8 @@ class CRM_Mautic_APIBatchList {
     }
     if (isset($items[$key])) {
       $this->offset += count($items[$key]);
-      return  $items[$key];
+      return $items[$key];
     }
   }
-  
+
 }

--- a/CRM/Mautic/BAO/MauticWebHook.php
+++ b/CRM/Mautic/BAO/MauticWebHook.php
@@ -30,15 +30,14 @@ class CRM_Mautic_BAO_MauticWebHook extends CRM_Mautic_DAO_MauticWebHook {
    * Gets an entity from the webhook.
    *
    * @param string $mauticEntityType
-   * @param string $webhookData
+   * @param array[] $webhookData
    *  API MauticWebHook data.
    *
    * @return []
    */
   public static function getProvidedData($mauticEntityType, $webhookData) {
-    $data = json_decode($webhookData, TRUE);;
-    if (!empty($data[$mauticEntityType])) {
-      return $data[$mauticEntityType];
+    if (!empty($webhookData[$mauticEntityType])) {
+      return $webhookData[$mauticEntityType];
     }
   }
 

--- a/CRM/Mautic/Contact/ContactMatch.php
+++ b/CRM/Mautic/Contact/ContactMatch.php
@@ -76,7 +76,7 @@ class CRM_Mautic_Contact_ContactMatch {
   /**
    * Apply deduping rules to find a civicrm contact id from Mautic contact data.
    *
-   * @param unknown $mauticContact
+   * @param array[] $mauticContact
    * @return NULL
    */
   public static function dedupeFromMauticContact($mauticContact) {

--- a/CRM/Mautic/Contact/ContactMatch.php
+++ b/CRM/Mautic/Contact/ContactMatch.php
@@ -4,7 +4,6 @@ use CRM_Mautic_Utils as U;
 
 /**
  * Matches Mautic Contacts with CiviCRM contacts.
- *
  */
 class CRM_Mautic_Contact_ContactMatch {
 
@@ -13,11 +12,10 @@ class CRM_Mautic_Contact_ContactMatch {
    */
   public const MAUTIC_ID_FIELD_ALIAS = 'civicrm_contact_id';
 
-
   /**
    * Retrieve available dedupe rule options for settings form.
    *
-   * @return array
+   * @return array[]
    */
   public static function getDedupeRules() {
     $dao = CRM_Core_DAO::executeQuery("
@@ -36,6 +34,9 @@ class CRM_Mautic_Contact_ContactMatch {
     return $rules;
   }
 
+  /**
+   * @return int|null
+   */
   public static function getMauticContactReferenceFieldId() {
     $mautic_field_info = CRM_Mautic_Utils::getContactCustomFieldInfo('Mautic_Contact_ID');
     return $mautic_field_info['id'] ?? NULL;
@@ -45,6 +46,8 @@ class CRM_Mautic_Contact_ContactMatch {
    * Find a contact with a reference to a Mautic Contact.
    *
    * @param int $mauticContactId
+   *
+   * @return mixed|void|NULL
    */
   public static function lookupMauticContactReference($mauticContactId) {
     if (!intval($mauticContactId)) {
@@ -77,7 +80,9 @@ class CRM_Mautic_Contact_ContactMatch {
    * Apply deduping rules to find a civicrm contact id from Mautic contact data.
    *
    * @param array[] $mauticContact
-   * @return NULL
+   *
+   * @return mixed|void|null
+   * @throws \CRM_Core_Exception
    */
   public static function dedupeFromMauticContact($mauticContact) {
     $ruleId = \Civi::settings()->get('mautic_webhook_dedupe_rule');
@@ -93,7 +98,7 @@ class CRM_Mautic_Contact_ContactMatch {
     $params['check_permission'] = FALSE;
     $dupes = CRM_Dedupe_Finder::dupesByParams($params, $contactType, $ruleType, [], $ruleId);
     if ($dupes) {
-      return !empty($dupes[0]) ? $dupes[0] : NULL;
+      return $dupes[0] ?? NULL;
     }
   }
 
@@ -105,7 +110,7 @@ class CRM_Mautic_Contact_ContactMatch {
    *  2. Field referencing the mautic contact on CiviCRM Contacts.
    *  3. Application of dedupe rules from contact values.
    *
-   * @param [] $mauticContact
+   * @param array[] $mauticContact
    *
    * @return int|NULL
    *  Id of a CiviCRM contact.
@@ -126,13 +131,13 @@ class CRM_Mautic_Contact_ContactMatch {
     }
     U::checkDebug("Looking for matching contact via dedupe rule.");
     return self::dedupeFromMauticContact($mauticContact);
-
   }
 
   /**
    * Attempt to find a Mautic Contact Id for a CiviCRM Contact.
    *
-   * @param array $contact
+   * @param array[] $contact
+   *
    * @return int|void
    */
   public static function getMauticFromCiviContact($contact) {

--- a/CRM/Mautic/Contact/FieldMapping.php
+++ b/CRM/Mautic/Contact/FieldMapping.php
@@ -41,7 +41,7 @@ class CRM_Mautic_Contact_FieldMapping {
    * @return mixed|string
    */
   public static function getValue($data, $civiFieldName, $default = '') {
-    $values = !empty($data['fields']['all']) ? $data['fields']['all'] : [];
+    $values = $data['fields']['all'] ?? [];
     $mapping = self::$defaultFieldMapping;
     $key = !empty($mapping[$civiFieldName]) ? $mapping[$civiFieldName] : '';
     return $key && isset($values[$key]) ? $values[$key] : $default;
@@ -99,7 +99,7 @@ class CRM_Mautic_Contact_FieldMapping {
    *
    * @return mixed
    */
-  protected static function lookupMauticValue($key, $data) {
+  public static function lookupMauticValue($key, $data) {
     if (isset($data[$key])) {
       return $data[$key];
     }

--- a/CRM/Mautic/Contact/FieldMapping.php
+++ b/CRM/Mautic/Contact/FieldMapping.php
@@ -42,8 +42,9 @@ class CRM_Mautic_Contact_FieldMapping {
 
   /**
    * Alter the converted contact communication prefs to include  subscription changes on Mautic.
-   * @param stdClass $mauticContact
-   * @param array $contact
+   *
+   * @param array[] $mauticContact
+   * @param array[] $contact
    */
   public static function commsPrefsMauticToCivi($mauticContact, &$contact) {
     // The doNotContact field appears to have an empty array when false and a nested empty array when true.
@@ -65,8 +66,8 @@ class CRM_Mautic_Contact_FieldMapping {
   /**
    * Sets doNotContact when Converting to a Mautic contact.
    *
-   * @param [] $civiContact
-   * @param [] $mauticContact
+   * @param array[] $civiContact
+   * @param array[] $mauticContact
    */
   public static function commsPrefsCiviToMautic($civiContact, &$mauticContact) {
     if (!empty($civiContact['is_opt_out']) || !empty($civiContact['do_not_email'])) {
@@ -87,11 +88,11 @@ class CRM_Mautic_Contact_FieldMapping {
    * look in the first level of properties then in the fields.
    *
    * @param string $key
-   * @param string $data
+   * @param array[] $data
+   *
    * @return mixed
    */
   protected static function lookupMauticValue($key, $data) {
-
     if (is_array($data)) {
       if (isset($data[$key])) {
         return $data[$key];
@@ -113,13 +114,14 @@ class CRM_Mautic_Contact_FieldMapping {
   /**
    * Converts between Mautic and CiviCRM values.
    *
-   * @param mixed $contactData
+   * @param array[] $contactData
    * @param boolean $civiToMautic
-   * @return mixed[]|array[]|string[]
+   *
+   * @return array[]
    */
   protected static function convertContact($contactData, $civiToMautic = TRUE) {
     $mapping = static::getMapping();
-    CRM_Mautic_Utils::checkDebug(__FUNCTION__, [$contactData, $mapping]);
+    CRM_Mautic_Utils::checkDebug(__FUNCTION__, ['contactData' => $contactData, 'fieldMapping' => $mapping]);
     if (!$civiToMautic) {
       $mapping = array_flip($mapping);
     }
@@ -138,6 +140,13 @@ class CRM_Mautic_Contact_FieldMapping {
     return $convertedContact;
   }
 
+  /**
+   * @param array $contact
+   *   CiviCRM contact
+   * @param bool $includeTags
+   *
+   * @return array[]
+   */
   public static function convertToMauticContact($contact, $includeTags = FALSE) {
     $mauticContact = static::convertContact($contact, TRUE);
     if ($includeTags) {
@@ -154,8 +163,10 @@ class CRM_Mautic_Contact_FieldMapping {
   /**
    * Converts mautic contact data to values for a civicrm contact.
    *
-   * @param mixed $mauticContact
-   * @return mixed[]|array|string[]
+   * @param array[] $mauticContact
+   * @param bool $includeTags
+   *
+   * @return array[]
    */
   public static function convertToCiviContact($mauticContact, $includeTags = FALSE) {
     $contact = static::convertContact($mauticContact, FALSE);

--- a/CRM/Mautic/Contact/FieldMapping.php
+++ b/CRM/Mautic/Contact/FieldMapping.php
@@ -33,6 +33,13 @@ class CRM_Mautic_Contact_FieldMapping {
     return $mapping;
   }
 
+  /**
+   * @param $data
+   * @param string $civiFieldName
+   * @param string $default
+   *
+   * @return mixed|string
+   */
   public static function getValue($data, $civiFieldName, $default = '') {
     $values = !empty($data['fields']['all']) ? $data['fields']['all'] : [];
     $mapping = self::$defaultFieldMapping;
@@ -93,21 +100,11 @@ class CRM_Mautic_Contact_FieldMapping {
    * @return mixed
    */
   protected static function lookupMauticValue($key, $data) {
-    if (is_array($data)) {
-      if (isset($data[$key])) {
-        return $data[$key];
-      }
-      if (isset($data['fields']['core'][$key]['value'])) {
-        return $data['fields']['core'][$key]['value'];
-      }
+    if (isset($data[$key])) {
+      return $data[$key];
     }
-    elseif (is_object($data)) {
-      if (isset($data->fields->core->{$key}->value)) {
-        return $data->fields->core->{$key}->value;
-      }
-      if (isset($data->{$key})) {
-        return $data->{$key};
-      }
+    if (isset($data['fields']['core'][$key]['value'])) {
+      return $data['fields']['core'][$key]['value'];
     }
   }
 
@@ -141,7 +138,7 @@ class CRM_Mautic_Contact_FieldMapping {
   }
 
   /**
-   * @param array $contact
+   * @param array[] $contact
    *   CiviCRM contact
    * @param bool $includeTags
    *

--- a/CRM/Mautic/Contact/FieldMapping.php
+++ b/CRM/Mautic/Contact/FieldMapping.php
@@ -177,13 +177,13 @@ class CRM_Mautic_Contact_FieldMapping {
 
   /**
    * Saves tags from a Mautic to a CiviCRM contact.
-   * @param mixed $mauticContact
+   * @param array[] $mauticContact
    * @param int $contactId
    */
   public static function saveMauticTagsToCiviContact($mauticContact, $contactId) {
     // Get the tags in the mautic contact.
     $tags = self::lookupMauticValue('tags', $mauticContact);
-    $tagNames = $tags ? array_map(function($t) { return $t->tag;}, $tags) : [];
+    $tagNames = $tags ? array_map(function($t) { return $t['tag'];}, $tags) : [];
     $tagHelper = new CRM_Mautic_Tag();
     $tagHelper->saveContactTags($tagNames, $contactId);
   }

--- a/CRM/Mautic/WebHook/Handler.php
+++ b/CRM/Mautic/WebHook/Handler.php
@@ -4,8 +4,6 @@ use CRM_Mautic_ExtensionUtil as E;
 use CRM_Mautic_Utils as U;
 
 /**
- * @class
- * /
  * Functionality for processing Mautic Webhooks.
  *
  * For each individual trigger event, tries to Match to a contact and creates a webhook entity and/or activity.
@@ -15,7 +13,7 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
   /**
    * Get corresponding CiviCRM contact from Mautic contact.
    *
-   * @param [] $mauticContact
+   * @param array[] $mauticContact
    *
    * @return int|NULL
    */
@@ -24,17 +22,18 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
   }
 
   /**
-   * @param [] $webhook
+   * @param array[] $webhook
    *
    * @throws \CiviCRM_API3_Exception
    */
   public function processEvent($webhook) {
     $data = json_decode($webhook['data'], TRUE);
     // Data may include lead and contact properties - they appear to be the same.
-    $contact = !empty($data['contact']) ? $data['contact'] : NULL;
+    $contact = $data['contact'] ?? NULL;
     U::checkDebug("webhook trigger", $webhook['webhook_trigger_type']);
     if (!$webhook['webhook_trigger_type'] || !$contact) {
       U::checkDebug("Processing Mautic webhook: trigger or contact not found exiting.");
+      $this->recordWebhookProcessed($webhook['id'], NULL, NULL);
       return;
     }
 
@@ -45,28 +44,41 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
     if (in_array($webhook['webhook_trigger_type'], $ignoreTriggersIfCiviModified)) {
       $connectedUserId = MC::singleton()->getConnectedUser()['id'] ?? NULL;
       if ($connectedUserId == $contact['id'] || $connectedUserId == $modifiedBy) {
-        U::checkDebug("WebHook: " . $webhook['webhook_trigger_type'] ." - Mautic Contact last modified by CiviCRM - no further processing required." );
+        U::checkDebug("WebHook: " . $webhook['webhook_trigger_type'] . " - Mautic Contact last modified by CiviCRM - no further processing required." );
+        $civicrmContactID = CRM_Mautic_Contact_FieldMapping::getValue($contact, 'civicrm_contact_id', NULL);
+        $this->recordWebhookProcessed($webhook['id'], $civicrmContactID, NULL);
         return;
       }
     }
 
     $civicrmContactID = $this->identifyContact($contact);
-    $activityId = NULL;
+    $activityID = NULL;
     // We have extracted enough information for an action.
     if ($civicrmContactID) {
       // Create an activity for this contact.
       // @todo Should this be a setting?
       // Then we let users choose whether to create one by default or in a civi rule.
       //
-      $activityId = $this->createActivity($webhook['webhook_trigger_type'], $civicrmContactID);
+      $activityID = $this->createActivity($webhook['webhook_trigger_type'], $civicrmContactID);
     }
     else {
       U::checkDebug("Webhook: no matching contact found for trigger: " . $webhook['webhook_trigger_type']);
     }
+    $this->recordWebhookProcessed($webhook['id'], $civicrmContactID, $activityID);
+  }
+
+  /**
+   * @param int $webhookID
+   * @param int $civicrmContactID
+   * @param int $activityID
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function recordWebhookProcessed($webhookID, $civicrmContactID, $activityID) {
     $params = [
-      'id' => $webhook['id'],
+      'id' => $webhookID,
       'contact_id' => $civicrmContactID,
-      'activity_id' => $activityId,
+      'activity_id' => $activityID,
       'processed_date' => date('YmdHis'),
     ];
     // Update the WebHook entity to store the data.
@@ -76,7 +88,10 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
 
   /**
    * Process incoming webhook.
-   * @param [] $data
+   *
+   * @param string $rawData
+   *
+   * @throws \CiviCRM_API3_Exception
    */
   public function process($rawData) {
     $data = json_decode($rawData, TRUE);
@@ -103,12 +118,10 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
   }
 
   /**
-   * @param $trigger
-   * @param $mauticContact
-   * @param $cid
-   * @param null $data
+   * @param string $trigger
+   * @param int $cid
    *
-   * @return mixed|null
+   * @return int|null
    * @throws \CiviCRM_API3_Exception
    */
   public function createActivity($trigger, $cid) {
@@ -130,6 +143,7 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
     ];
     $result = civicrm_api3('Activity', 'create', $params);
     U::checkDebug('Created mautic webhook activity');
-    return !empty($result['id']) ? $result['id'] : NULL;
+    return $result['id'] ?? NULL;
   }
+
 }

--- a/CRM/Mautic/WebHook/Handler.php
+++ b/CRM/Mautic/WebHook/Handler.php
@@ -110,7 +110,6 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
           civicrm_api3('MauticWebHook', 'create', [
             'data' => json_encode($item),
             'webhook_trigger_type' => $trigger,
-            'processed' => 0,
           ]);
         }
       }

--- a/api/v3/MauticWebHook.php
+++ b/api/v3/MauticWebHook.php
@@ -61,7 +61,7 @@ function civicrm_api3_mautic_web_hook_process($params) {
   if (!isset($params['processed_date'])) {
     $params['processed_date'] = ['IS NULL' => 1];
   }
-  $webhooks = civicrm_api3('MauticWebHook', 'Get', $params)['values'];
+  $webhooks = civicrm_api3('MauticWebHook', 'get', $params)['values'];
   $mauticWebhookHandler = new CRM_Mautic_WebHook_Handler();
   foreach ($webhooks as $webhook) {
     $mauticWebhookHandler->processEvent($webhook);


### PR DESCRIPTION
* Fix syncing contact ID back to mautic on new CiviCRM contact create
* Fix creating of new mautic tags in CiviCRM when they have been created in Mautic.
* Code cleanup, remove some debug timing and fix invalid exception class.
* Fix recording of webhook processed_date when no processing is required so we don't keep trying to process it.
* Fix mapping of webhook contact ID for civirules triggers/conditions/actions.
* Don't trigger civirules for webhooks that should not be processed further.