### PR TITLE
1.2

### DIFF
--- a/CRM/Civirules/Trigger/MauticWebHook.php
+++ b/CRM/Civirules/Trigger/MauticWebHook.php
@@ -74,13 +74,13 @@ class CRM_Civirules_Trigger_MauticWebHook extends CRM_Civirules_Trigger_Post {
     $hook_invoker->hook_civirules_alterTriggerData($triggerData);
 
     // Set the trigger contact id to the WebHook data.
-    $webhook = $triggerData->getEntityData('mauticwebhook');
+    $webhook = $triggerData->getEntityData('MauticWebHook');
     // Retrieve all data for webhook
     $originalData = $triggerData->getOriginalData();
     $webhook = array_merge($originalData, $webhook);
     // Decode webhook data
     $webhook['data'] = json_decode($webhook['data'], TRUE);
-    $triggerData->setEntityData('mauticwebhook', $webhook);
+    $triggerData->setEntityData('MauticWebHook', $webhook);
     // Set contact ID from mautic data
     if (!$triggerData->getContactId()) {
       $contact = CRM_Mautic_BAO_MauticWebHook::getProvidedData('contact', $webhook['data']);

--- a/CRM/Mautic/Form/PushSync.php
+++ b/CRM/Mautic/Form/PushSync.php
@@ -24,7 +24,8 @@ class CRM_Mautic_Form_PushSync extends CRM_Core_Form {
         return;
       }
       $output_stats = [];
-      $this->assign('dry_run', $stats['dry_run']);
+      $this->assign('dry_run', $stats['dry_run'] ?? NULL);
+      $this->assign('mauticDeletedInCivi', $stats['deletedInCivi'] ?? NULL);
       foreach ($groups as $group_id => $details) {
         if (empty($details['segment_name'])) {
           continue;

--- a/CRM/Mautic/Sync.php
+++ b/CRM/Mautic/Sync.php
@@ -427,7 +427,7 @@ class CRM_Mautic_Sync {
 
   /**
    * For matched civi contacts, update the custom fields that reference a mautic contact.
-   * @return array[]
+   * @return array
    */
   public function updateContactReferenceFields() {
     $stats = ['updatedContactReferenceFields' => 0];
@@ -486,10 +486,15 @@ class CRM_Mautic_Sync {
     ';
     $deletedInCiviDao = CRM_Core_DAO::executeQuery($deletedInCiviQuery);
     while ($deletedInCiviDao->fetch()) {
-      $deletedInCivi[] = "{$deletedInCiviDao->mautic_contact_id}:{$deletedInCiviDao->civicrm_contact_id}";
+      $deletedInCivi[] = [
+        'mautic_cid' => $deletedInCiviDao->mautic_contact_id,
+        'civicrm_cid' => $deletedInCiviDao->civicrm_contact_id
+      ];
     }
     if (!empty($deletedInCivi)) {
-      \Civi::log()->warning('Contacts in Mautic with CiviCRM contact IDs that do not exist in CiviCRM: ' . implode(', ', $deletedInCivi));
+      $stats['deletedInCivi'] = $deletedInCivi;
+      \Civi::log()->warning('Contacts in Mautic with CiviCRM contact IDs that do not exist in CiviCRM: ' . print_r
+        ($deletedInCivi, TRUE));
     }
 
     return $stats;

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -9,6 +9,11 @@ Releases use the following numbering system:
 
 * **[BC]**: Items marked with [BC] indicate a breaking change that will require updates to your code if you are using that code in your extension.
 
+## Release 1.2
+
+* Display missing CiviCRM contacts on manual sync summary.
+* CiviRules (2.23) now enforces case sensitive for entities.
+
 ## Release 1.1
 
 * Catch errors and continue processing webhooks if one fails.

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-02-15</releaseDate>
-  <version>1.1</version>
+  <releaseDate>2021-03-21</releaseDate>
+  <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.28</ver>

--- a/templates/CRM/Mautic/Form/PushSync.tpl
+++ b/templates/CRM/Mautic/Form/PushSync.tpl
@@ -1,4 +1,4 @@
-<div class="crm-block crm-form-block crm-campaignmonitor-sync-form-block">
+<div class="crm-block crm-form-block crm-mautic-sync-form-block">
   {if $smarty.get.state eq 'done'}
     <div class="help">
       {if $dry_run}
@@ -6,7 +6,7 @@
         {ts}<strong>Dry Run: no changes made.</strong>{/ts}
       {/if}
         </p>
-      {ts}Push completed:{/ts}<br/> 
+      {ts}Push completed:{/ts}<br/>
       {foreach from=$stats item=group}
       <h2>{$group.name}</h2>
       <table class="form-layout-compressed">
@@ -32,7 +32,23 @@
       <td>{$msg.message}</td>
     </tr>
     {/foreach}
+    </tbody>
     </table>
+    {/if}
+    {if $mauticDeletedInCivi}
+      <h2>Contacts in Mautic with CiviCRM contact IDs that do not exist in CiviCRM</h2>
+      <p>This can happen when you have deleted a contact in CiviCRM.</p>
+      <table>
+        <thead><tr><th>Mautic Contact ID</th><th>CiviCRM Contact ID</th></tr></thead>
+        <tbody>
+        {foreach from=$mauticDeletedInCivi item=msg}
+          <tr>
+            <td>{$msg.mautic_cid}</td>
+            <td>{$msg.civicrm_cid}</td>
+          </tr>
+        {/foreach}
+        </tbody>
+      </table>
     {/if}
   {else}
     <h3>{ts}Push contacts from CiviCRM to Mautic{/ts}</h3>


### PR DESCRIPTION
* Display missing CiviCRM contacts on manual sync summary.
* CiviRules (2.23) now enforces case sensitive for entities.