### PR TITLE
Change tags segments

### DIFF
--- a/CRM/Civirules/Action/MauticChangeTagsSegments.php
+++ b/CRM/Civirules/Action/MauticChangeTagsSegments.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ *
+ * CiviRules action to change Mautic Segment and/or Tags for a contact.
+ */
+
+use CRM_Mautic_ExtensionUtil as E;
+use CRM_Mautic_Connection as MC;
+use CRM_Mautic_Contact_Contact as MauticContact;
+use CRM_Mautic_Utils as U;
+
+class CRM_Civirules_Action_MauticChangeTagsSegments extends CRM_Civirules_Action {
+
+  protected $ruleAction = [];
+
+  protected $action = [];
+
+  /**
+   * Process the action
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   * @access public
+   */
+  public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData) {
+    U::checkDebug(__CLASS__ . ' action triggerred', $this->ruleAction);
+    $civicrmContactID = $triggerData->getContactId();
+    if (empty($civicrmContactID)) {
+      return;
+    }
+    $params = $this->getActionParameters();
+
+    
+    $addSegmentIds = $params['add_segment_ids'] ?? [];
+    $removeSegmentIds = $params['remove_segment_ids'] ?? [];
+    $addTags = $params['add_tags'];
+    $removeTags = $params['remove_tags'];
+    $contact = new MauticContact($civicrmContactID);
+    $mauticContactId = $contact->pushToMautic(TRUE);
+    CRM_Core_Error::debug_var(__FUNCTION__, [$mauticContactId, $addTags, $addSegmentIds]);
+    if ($mauticContactId) {
+      try {
+        $segmentApi = MC::singleton()->newApi('segments');
+        foreach ($removeSegmentIds as $segmentId) {
+          $segmentApi->removeContact($segmentId, $mauticContactId);
+        }
+        foreach ($addSegmentIds as $segmentId) {
+          $segmentApi->addContact($segmentId, $mauticContactId);
+        }
+        if ($addTags || $removeTags) {
+          $tags = $addTags +  array_map(function($t) { return '-' . $t;}, $removeTags);
+          CRM_Core_Error::debug_var(__FUNCTION__, $tags);
+          $contact->pushToMautic(FALSE, ['tags' => $tags]);
+        }
+      }
+      catch (Exception $e) {
+        CRM_Core_Error::debug_log_message($e->getMessage());
+      }
+    }
+  }
+  /**
+   *
+   */
+  public function userFriendlyConditionParams() {
+    $params = $this->getActionParameters();
+    $labels = [
+      'add_segment_ids' => E::ts('Add Segments'),
+      'remove_segment_ids' => E::ts('Remove Segments'),
+      'add_tags' => E::ts('Add Tags'),
+      'remove_tags' => E::ts('Remove Tags'),
+    ];
+    $return = '';
+    foreach ($labels  as $key => $label) {
+      if ($params[$key]) {
+        $val = $params[$key];
+        if (strpos($key, 'segment_ids')) {
+          $selections = array_intersect_key(U::getMauticSegmentOptions(FALSE), array_flip($val));
+        }
+        else {
+          $selections = $val;
+        }
+        $return .= $label . ': ' .implode(', ', $selections) . '. <br />';
+      }
+    }
+    return $return;
+  }
+
+ /**
+  * @inherit
+  */ 
+  protected function getActionParameters() {
+    $params = parent::getActionParameters();
+    foreach (['add_segment_ids', 'remove_segment_ids', 'add_tags', 'remove_tags'] as $key) {
+      $params[$key] = $this->arrVal($params[$key]);  
+    }
+    return $params;
+  }
+
+  public function arrVal($str) {
+    return !is_array($str) ? array_filter(explode(',', $str)) : $str;
+  }
+
+
+  /**
+   *
+   * {@inheritDoc}
+   * @see CRM_Civirules_Action::getExtraDataInputUrl()
+   */
+  public function getExtraDataInputUrl($ruleActionId) {
+    return CRM_Utils_System::url('civicrm/admin/mautic/civirules/action/mautic_tags_segment', 'rule_action_id=' . $ruleActionId);
+  }
+}

--- a/CRM/Mautic/Contact/Contact.php
+++ b/CRM/Mautic/Contact/Contact.php
@@ -1,0 +1,103 @@
+<?php
+
+use Civi\Api4\Contact;
+use CRM_Mautic_Connection as MC;
+use CRM_Mautic_Contact_FieldMapping as FieldMapping;
+use CRM_Mautic_Contact_ContactMatch as ContactMatch;
+use CRM_Mautic_Utils as U;
+
+/**
+ * @class
+ * Functionality for pushing a single contact to Mautic.
+ *
+ *
+ */
+class CRM_Mautic_Contact_Contact {
+  
+  private $civicmContactID;
+
+  private $civicrmContact = [];
+
+  private $mauticAPI;
+  
+  /**
+   * Create an instance.
+   *
+   * @param int $civicrmContactID
+   */
+  public function __construct($civicrmContactID) {
+    $this->civicrmContactID = $civicrmContactID;
+    $this->mauticAPI = MC::singleton()->newApi('contacts');
+  }
+
+
+  /**
+   * Loads CiviCRM Contact data for a  Mautic push.
+   *
+   * @return array
+   */
+  public function getCiviCRMContact($reset = FALSE) {
+    if (!$this->civicrmContact || $reset) {
+      $fields = FieldMapping::getMapping();
+      unset($fields['civicrm_contact_id']);
+      $fields = array_merge(array_keys($fields), FieldMapping::getCommsPrefsFields());
+      $this->civicrmContact = Contact::get(FALSE)
+        ->addSelect(...$fields)
+        ->addWhere('id', '=', $this->civicrmContactID)
+        ->execute()
+        ->first();
+    }
+    return $this->civicrmContact;
+  }
+
+
+  /**
+   * Get the Mautic Contact ID.
+   * 
+   * @return int
+   */
+  public function getMauticContactID() {
+    return ContactMatch::getMauticContactIDFromCiviContact($this->getCiviCRMContact());
+  }
+
+
+  /**
+   * Push the contact to Mautic.
+   *
+   * @param bool $skipIfExists
+   *  Whether to skip if the contact already exists.
+   *
+   * @param array $params
+   *  Additonal property values for the Mautic contact.
+   *  
+   *  
+   * @return int
+   *  Mautic Contact ID
+   */
+  public function pushToMautic($skipIfExists = TRUE, $params = []) {
+    $mauticID = $this->getMauticContactID();
+    $contact = $this->getCiviCRMContact();
+    $mauticContact = array_merge(FieldMapping::convertToMauticContact($contact), $params);
+
+    U::$skipUpdatesToMautic = TRUE;
+    if (!$mauticID) {
+      $response = $this->mauticAPI->create($mauticContact);
+      $mauticID = $response['contact']['id'];
+      U::saveMauticIDCustomField($contact, $mauticID);
+      $this->resetData();
+    }
+    elseif (!$skipIfExists) {
+      $response = $this->mauticAPI->edit($mauticID, $mauticContact);
+    }
+    U::$skipUpdatesToMautic = FALSE;
+    return $mauticID;
+  }
+
+  /**
+   * Reset Contact Data.
+   */
+  private function resetData() {
+    $this->civicrmContact = [];
+  }
+
+}

--- a/CRM/Mautic/Form/Civirules/Action/MauticChangeTagsSegments.php
+++ b/CRM/Mautic/Form/Civirules/Action/MauticChangeTagsSegments.php
@@ -1,0 +1,138 @@
+<?php
+
+use CRM_Mautic_ExtensionUtil as E;
+use  CRM_Mautic_Utils as U;
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_Mautic_Form_Civirules_Action_MauticChangeTagsSegments extends CRM_CivirulesActions_Form_Form {
+  public function buildQuickForm() {
+    $segments = U::getMauticSegmentOptions(TRUE);
+    $tags = U::getMauticTagOptions();
+    $this->add('hidden', 'rule_action_id');
+    $this->add(
+      'select2', 
+      'add_segment_ids',
+      E::ts('Add Segments'),
+      $segments,
+      FALSE,
+      ['multiple' => TRUE]
+    );
+    $this->add(
+      'select2', 
+      'remove_segment_ids',
+      E::ts('Remove Segments'),
+      $segments,
+      FALSE,
+      ['multiple' => TRUE]
+    );
+    $this->add(
+      'select2', 
+      'add_tags',
+      E::ts('Add Tags'),
+      $tags,
+      FALSE,
+      ['multiple' => TRUE]
+    );
+    $this->add(
+      'select2', 
+      'remove_tags',
+      E::ts('Remove Tags'),
+      $tags,
+      FALSE,
+      ['multiple' => TRUE]
+    );
+    $this->addButtons(array(
+      array(
+        'type' => 'submit',
+        'name' => E::ts('Submit'),
+        'isDefault' => TRUE,
+      ),
+    ));
+
+    // export form elements
+    $this->assign('elementNames', $this->getRenderableElementNames());
+    parent::buildQuickForm();
+  }
+
+  public function addRules() {
+    $this->addFormRule([__CLASS__, 'validateForm']);
+  }
+
+  public static function arrVal($str) {
+    return array_filter(explode(',', $str));
+  }
+
+  /**
+   * Validation callback.
+   */
+  public static function validateForm($values) {
+    $errors = [];
+    $addTags = self::arrVal($values['add_tags']);
+    $removeTags = self::arrVal($values['remove_tags']);
+    $addSegment = self::arrVal($values['add_segment_ids']);
+    $removeSegment = self::arrVal($values['remove_segment_ids']);
+    if (!$addTags && !$removeTags && !$addSegment && !$removeSegment) {
+      $errors[] = E::ts('Please specify an action.');
+    }
+    if (array_intersect($addSegment, $removeSegment)) {
+      $errors['remove_segment_ids'] = E::ts('You cannot add and remove the same segment.');
+    }
+    if (array_intersect($addTags, $removeTags)) {
+      $errors['remove_tags'] = E::ts('You cannot add and remove the same tag.');
+    }
+    return empty($errors) ? TRUE : $errors;
+  }
+  
+  /**
+   * Overridden parent method to process form data after submitting
+   *
+   * @access public
+   */
+  public function postProcess() {
+    $data = [];
+    foreach ($this->getRenderableElementNames() as $name) {
+      $data[$name] = $this->_submitValues[$name];
+    }
+    $this->ruleAction->action_params = serialize($data);
+    $this->ruleAction->save();
+    parent::postProcess();
+  }
+  
+  /**
+   * 
+   * {@inheritDoc}
+   * @see CRM_CivirulesActions_Form_Form::setDefaultValues()
+   */
+  public function setDefaultValues() {
+    $defaultValues = parent::setDefaultValues();
+    $params = !empty($this->ruleAction->action_params) ? unserialize($this->ruleAction->action_params) : []; 
+    $defaultValues += $params;
+    return $defaultValues;
+  }
+  
+
+  /**
+   * Get the fields/elements defined in this form.
+   *
+   * @return array (string)
+   */
+  public function getRenderableElementNames() {
+    // The _elements list includes some items which should not be
+    // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
+    // items don't have labels.  We'll identify renderable by filtering on
+    // the 'label'.
+    $elementNames = array();
+    foreach ($this->_elements as $element) {
+      /** @var HTML_QuickForm_Element $element */
+      $label = $element->getLabel();
+      if (!empty($label)) {
+        $elementNames[] = $element->getName();
+      }
+    }
+    return $elementNames;
+  }
+}

--- a/CRM/Mautic/Upgrader.php
+++ b/CRM/Mautic/Upgrader.php
@@ -149,6 +149,12 @@ class CRM_Mautic_Upgrader extends CRM_Mautic_Upgrader_Base {
     $this->enableCiviRules();
     return TRUE;
   }
+
+  public function upgrade_4208() {
+    $this->ctx->log->info('Action to change a Contact\'s Tags/Segments.');
+    $this->enableCiviRules();
+    return TRUE;
+  }
   
 
 }

--- a/CRM/Mautic/Utils.php
+++ b/CRM/Mautic/Utils.php
@@ -76,13 +76,21 @@ class CRM_Mautic_Utils {
 
 
   /**
-   * Gets Mautic Segments in [id] => label format.
+   * Gets Mautic Segments as a set of options.
+   *
+   * @param bool $select2Format
+   *
    * @return string[]
    */
-  public static function getMauticSegmentOptions() {
+  public static function getMauticSegmentOptions($select2Format = FALSE) {
     $options = [];
     foreach (self::getMauticSegments() as $segment) {
-      $options[$segment['id']] = $segment['name'];
+      if ($select2Format) {
+        $options[] = ['id' => $segment['id'], 'text' => $segment['name']];
+      }
+      else {
+        $options[$segment['id']] = $segment['name'];
+      }
     }
     return $options;
   }
@@ -267,6 +275,25 @@ class CRM_Mautic_Utils {
       ]);
       return $event['custom_' . $segmentFid] ?? NULL;
     }
+  }
+
+  /**
+   * Gets Mautic Tags as select2 options.
+   *
+   * @return array
+   */
+  public static function getMauticTagOptions() {
+    if (!isset(\Civi::$statics[__FUNCTION__]['tags'])) {
+      $api = MC::singleton()->newApi('tags');
+      $limit = 200;
+      $res = $api->getList('', 0, $limit, 'tag', 'asc', TRUE, TRUE);
+      \Civi::$statics[__CLASS__]['tags'] = [];
+      foreach ($res['tags'] as $id => $tag) {
+        \Civi::$statics[__CLASS__]['tags'][] = ['id' => $tag['tag'], 'text' => $tag['tag']];
+      }
+    }
+    return \Civi::$statics[__CLASS__]['tags'];
+  
   }
 
   /**

--- a/api/v3/Mautic/Getchecksum.php
+++ b/api/v3/Mautic/Getchecksum.php
@@ -1,0 +1,53 @@
+<?php
+use CRM_Mautic_ExtensionUtil as E;
+
+/**
+ * Mautic.Getchecksum API specification (optional)
+ * This is used for documentation and validation.
+ *
+ * @param array $spec description of fields supported by this API call
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
+ */
+function _civicrm_api3_mautic_Getchecksum_spec(&$spec) {
+  $spec['id']['api.required'] = 1;
+}
+
+/**
+ * Mautic.Getchecksum API
+ *
+ * @param array $params
+ *
+ * @return array
+ *   API result descriptor
+ *
+ * @see civicrm_api3_create_success
+ *
+ * @throws API_Exception
+ */
+function civicrm_api3_mautic_Getchecksum($params) {
+
+  if (array_key_exists('id', $params)) {
+    $returnValues = [];
+    $cids = [];
+    if (is_numeric($params['id'])) {
+      $cids = [$params['id']];
+    }
+    elseif (!empty($params['id']['IN'])) {
+      $cids = $params['id']['IN'];
+    }
+    elseif (is_array($params['id'])) {
+      $cids = $params['id'];
+    }
+    foreach ($cids as $cid) {
+      if (!is_numeric($cid)) {
+        continue;
+      }
+      $returnValues[$cid] = CRM_Contact_BAO_Contact_Utils::generateChecksum($cid);
+    }
+    return civicrm_api3_create_success($returnValues, $params, 'Mautic', 'Getchecksum');
+  }
+  else {
+    throw new API_Exception('The id parameter is required');
+  }
+}

--- a/mautic.civix.php
+++ b/mautic.civix.php
@@ -91,9 +91,9 @@ function _mautic_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {

--- a/sql/civirules/actions.json
+++ b/sql/civirules/actions.json
@@ -1,5 +1,6 @@
 [
   {"name":"mautic_contact_sync_to_mautic","label":"Sync contact to Mautic","class_name":"CRM_Civirules_Action_ContactSyncToMautic"},
   {"name":"mautic_create_contact","label":"Create Contact from Mautic WebHook Data","class_name":"CRM_Civirules_Action_MauticWebHookCreateContact"},
-  {"name":"mautic_add_to_event_segment","label":"Add contact to Segment mapped to an Event","class_name":"CRM_Civirules_Action_MauticAddToEventSegment"}
+  {"name":"mautic_add_to_event_segment","label":"Add contact to Segment mapped to an Event","class_name":"CRM_Civirules_Action_MauticAddToEventSegment"},
+  {"name":"mautic_tags_segment","label":"Change Mautic tags and segments for a contact","class_name":"CRM_Civirules_Action_MauticChangeTagsSegments"}
 ]

--- a/templates/CRM/Mautic/Form/Civirules/Action/MauticChangeTagsSegments.tpl
+++ b/templates/CRM/Mautic/Form/Civirules/Action/MauticChangeTagsSegments.tpl
@@ -1,0 +1,17 @@
+{* HEADER *}
+
+<div class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="top"}
+</div>
+
+{foreach from=$elementNames item=elementName}
+  <div class="crm-section">
+    <div class="label">{$form.$elementName.label}</div>
+    <div class="content">{$form.$elementName.html}</div>
+    <div class="clear"></div>
+  </div>
+{/foreach}
+
+<div class="crm-submit-buttons">
+{include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>

--- a/tests/phpunit/api/v3/Mautic/GetchecksumTest.php
+++ b/tests/phpunit/api/v3/Mautic/GetchecksumTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Mautic.Getchecksum API Test Case
+ * This is a generic test class implemented with PHPUnit.
+ * @group headless
+ */
+class api_v3_Mautic_GetchecksumTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  /**
+   * Set up for headless tests.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * The setup() method is executed before the test is executed (optional).
+   */
+  public function setUp() {
+    parent::setUp();
+  }
+
+  /**
+   * The tearDown() method is executed after the test was executed (optional)
+   * This can be used for cleanup.
+   */
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Simple example test case.
+   *
+   * Note how the function name begins with the word "test".
+   */
+  public function testApiExample() {
+    $result = civicrm_api3('Mautic', 'getchecksum', array('magicword' => 'sesame'));
+    $this->assertEquals('Twelve', $result['values'][12]['name']);
+  }
+
+}

--- a/xml/Menu/mautic.xml
+++ b/xml/Menu/mautic.xml
@@ -48,4 +48,10 @@
     <title>Mautic Condition: Contact has field value</title>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/mautic/civirules/action/mautic_tags_segment</path>
+    <page_callback>CRM_Mautic_Form_Civirules_Action_MauticChangeTagsSegments</page_callback>
+    <title>Mautic Action: Change Contact Tags or Segments</title>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
Add Civirules action to add or remove arbitrary tags/segments for a Mautic contact.
Tags and Segments are set in the  Action configuration form, so are independent of Group/Event Synchronisation. 