### PR TITLE
Fixes and update

### DIFF
--- a/CRM/Mautic/WebHook/Handler.php
+++ b/CRM/Mautic/WebHook/Handler.php
@@ -55,6 +55,11 @@ class CRM_Mautic_WebHook_Handler extends CRM_Mautic_WebHook {
       if ($connectedUserId == $contact['id'] || $connectedUserId == $modifiedBy) {
         U::checkDebug("WebHook: " . $webhook['webhook_trigger_type'] . " - Mautic Contact last modified by CiviCRM - no further processing required." );
         $civicrmContactID = CRM_Mautic_Contact_FieldMapping::lookupMauticValue('civicrm_contact_id', $contact);
+        if (empty($civicrmContactID)) {
+          // This usually happens because a contact on the CiviCRM side has been deleted or merged
+          \Civi::log(E::SHORT_NAME)->warning("Mautic Webhook: no CiviCRM contact ID for Mautic contact: " . $contact['id'] . ': ' . $webhook['webhook_trigger_type']);
+          return;
+        }
         // Use a direct SQL query to bypass hooks (as we don't want to trigger civirules)
         $query = 'UPDATE civicrm_mauticwebhook SET processed_date=%1,contact_id=%3 WHERE id=%2';
         $queryParams = [

--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">https://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-06-28</releaseDate>
-  <version>1.4</version>
+  <releaseDate>2021-09-06</releaseDate>
+  <version>1.99.4</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.35</ver>
@@ -23,4 +23,7 @@
   <civix>
     <namespace>CRM/Mautic</namespace>
   </civix>
+  <tags>
+    <tag>mgmt:noupgrade</tag>
+  </tags>
 </extension>

--- a/info.xml
+++ b/info.xml
@@ -14,16 +14,26 @@
     <url desc="Support">https://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-09-06</releaseDate>
-  <version>1.99.4</version>
+  <releaseDate>2022-10-28</releaseDate>
+  <version>1.4.1</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.35</ver>
+    <ver>5.49</ver>
   </compatibility>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
   <civix>
     <namespace>CRM/Mautic</namespace>
+    <format>22.05.2</format>
   </civix>
   <tags>
     <tag>mgmt:noupgrade</tag>
   </tags>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>mgd-php@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mautic.civix.php
+++ b/mautic.civix.php
@@ -108,19 +108,6 @@ function _mautic_civix_civicrm_config(&$config = NULL) {
 }
 
 /**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _mautic_civix_civicrm_xmlMenu(&$files) {
-  foreach (_mautic_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
@@ -218,136 +205,6 @@ function _mautic_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
- * for backward compatibility of extension code that uses it.
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array
- */
-function _mautic_civix_find_files($dir, $pattern) {
-  return CRM_Utils_File::findFiles($dir, $pattern);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _mautic_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _mautic_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _mautic_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_mautic_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _mautic_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _mautic_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _mautic_civix_civicrm_themes(&$themes) {
-  $files = _mautic_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- *
- * @return array
- */
-function _mautic_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
-}
-
-/**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
@@ -426,18 +283,6 @@ function _mautic_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
     if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
       _mautic_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _mautic_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
   }
 }
 

--- a/mautic.php
+++ b/mautic.php
@@ -14,13 +14,6 @@ function mautic_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- */
-function mautic_civicrm_xmlMenu(&$files) {
-  _mautic_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  */
 function mautic_civicrm_install() {
@@ -60,32 +53,6 @@ function mautic_civicrm_disable() {
  */
 function mautic_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   return _mautic_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- */
-function mautic_civicrm_managed(&$entities) {
-  _mautic_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- */
-function mautic_civicrm_angularModules(&$angularModules) {
-  _mautic_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- */
-function mautic_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _mautic_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
 /**
@@ -149,7 +116,6 @@ function mautic_civicrm_buildForm($formName, &$form) {
     }
   }
 }
-
 
 /**
  * Implements hook_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors)
@@ -234,7 +200,6 @@ function mautic_civicrm_customPre(string $op, int $groupID, int $entityID, array
   }
 }
 
-
  /**
  * Implements hook_civicrm_pageRun().
  *
@@ -299,25 +264,6 @@ function mautic_civicrm_navigationMenu(&$menu) {
     'separator' => 0,
   ]);
   _mautic_civix_navigationMenu($menu);
-}
-
-/**
- * Implements hook_civicrm_merge().
- *
- * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_merge/
- *
- * @param string $type
- * @param mixed $data
- * @param int $mainId
- * @param int $otherId
- * @param array $tables
- */
-function mautic_civicrm_merge($type, $data, $mainId, $otherId, $tables) {
-  // @todo.
-  // If there is a contact with civicrm_contact_id of $otherId,
-  // Update it to reference mainId.
-  // if ($type == 'sqls') {
-  //}
 }
 
 function mautic_civicrm_entityTypes(&$entityTypes) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/tests/phpunit/api/v3/Mautic/PushsyncTest.php
+++ b/tests/phpunit/api/v3/Mautic/PushsyncTest.php
@@ -9,7 +9,7 @@ use Civi\Test\TransactionalInterface;
  * This is a generic test class implemented with PHPUnit.
  * @group headless
  */
-class api_v3_Mautic_PushsyncTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_Mautic_PushsyncTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().


### PR DESCRIPTION
- Update civix to latest version.
- Only allow one instance of the webhook processor to run at a time (supersedes #40)
- Log and return when processing webhook and civicrm contact ID doesn't exist.