### PR TITLE
 Fix timing issues and improve extension lifecycle management

### DIFF
--- a/CRM/Civirules/Action/ContactSyncToMautic.php
+++ b/CRM/Civirules/Action/ContactSyncToMautic.php
@@ -9,9 +9,9 @@ use CRM_Mautic_Connection as MC;
 
 class CRM_Civirules_Action_ContactSyncToMautic extends CRM_Civirules_Action {
 
-  protected $ruleAction = [];
+  protected array $ruleAction = [];
 
-  protected $action = [];
+  protected array $action = [];
 
   /**
    * Process the action

--- a/CRM/Civirules/Action/MauticAddToEventSegment.php
+++ b/CRM/Civirules/Action/MauticAddToEventSegment.php
@@ -12,9 +12,9 @@ class CRM_Civirules_Action_MauticAddToEventSegment extends CRM_Civirules_Action 
 
   use CRM_Civirules_EventMauticTrait;
 
-  protected $ruleAction = [];
+  protected array $ruleAction = [];
 
-  protected $action = [];
+  protected array $action = [];
 
   /**
    * Process the action

--- a/CRM/Civirules/Action/MauticChangeTagsSegments.php
+++ b/CRM/Civirules/Action/MauticChangeTagsSegments.php
@@ -13,11 +13,11 @@ class CRM_Civirules_Action_MauticChangeTagsSegments extends CRM_Civirules_Action
  /**
   * Keep a log of items processed in this request.
   */ 
- private static $processedIds = [];
+  private static $processedIds = [];
 
-  protected $ruleAction = [];
+  protected array $ruleAction = [];
 
-  protected $action = [];
+  protected array $action = [];
 
   /**
    * Process the action

--- a/CRM/Civirules/Action/MauticWebhookCreateContact.php
+++ b/CRM/Civirules/Action/MauticWebhookCreateContact.php
@@ -10,9 +10,9 @@ use CRM_Mautic_ExtensionUtil as E;
  */
 class CRM_Civirules_Action_MauticWebhookCreateContact extends CRM_Civirules_Action {
 
-  protected $ruleAction = [];
+  protected array $ruleAction = [];
 
-  protected $action = [];
+  protected array $action = [];
 
   /**
    * Process the action

--- a/CRM/Mautic/Upgrader.php
+++ b/CRM/Mautic/Upgrader.php
@@ -80,6 +80,10 @@ class CRM_Mautic_Upgrader extends CRM_Extension_Upgrader_Base {
     // Add Custom Data for Mautic_Webhook_Triggered activity type.
     $file = $this->extensionDir . '/xml/activity_data.xml';
     $this->executeCustomDataFileByAbsPath($file);
+    
+    // Add Custom Data for Mautic Event fields.
+    $eventFile = $this->extensionDir . '/xml/event_data.xml';
+    $this->executeCustomDataFileByAbsPath($eventFile);
   }
 
   /**
@@ -156,5 +160,66 @@ class CRM_Mautic_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Uninstall - remove custom data and other artifacts.
+   */
+  public function onUninstall()
+  {
+    // Define custom groups to remove
+    $customGroups = [
+      'Mautic_Contact',
+      'Mautic_Settings',
+      'Mautic_Event',
+      'Mautic_Webhook_Data',
+    ];
+    
+    // Remove custom groups
+    foreach ($customGroups as $groupName) {
+      try {
+        $customGroup = civicrm_api3('CustomGroup', 'get', [
+          'name' => $groupName,
+          'sequential' => 1,
+        ]);
+        if (!empty($customGroup['values'])) {
+          civicrm_api3('CustomGroup', 'delete', ['id' => $customGroup['values'][0]['id']]);
+        }
+      } catch (Exception $e) {
+        CRM_Core_Error::debug_log_message("Failed to remove $groupName custom group: " . $e->getMessage());
+      }
+    }
+    
+    // Remove other artifacts
+    $artifacts = [
+      [
+        'entity' => 'OptionValue',
+        'params' => [
+          'name' => 'Mautic_Webhook_Triggered',
+          'option_group_id' => 'activity_type',
+        ],
+        'description' => 'Mautic activity type',
+      ],
+      [
+        'entity' => 'OptionGroup',
+        'params' => ['name' => 'mautic_trigger_event'],
+        'description' => 'Mautic trigger event option group',
+      ],
+      [
+        'entity' => 'Job',
+        'params' => ['name' => 'Mautic Push Sync'],
+        'description' => 'Mautic scheduled job',
+      ],
+    ];
+    
+    foreach ($artifacts as $artifact) {
+      try {
+        $result = civicrm_api3($artifact['entity'], 'get', $artifact['params'] + ['sequential' => 1]);
+        if (!empty($result['values'])) {
+          civicrm_api3($artifact['entity'], 'delete', ['id' => $result['values'][0]['id']]);
+        }
+      } catch (Exception $e) {
+        $this->ctx->log->err("Failed to remove {$artifact['description']}: " . $e->getMessage());
+      }
+    }
+  }
 
 }

--- a/mautic.php
+++ b/mautic.php
@@ -48,11 +48,7 @@ function mautic_civicrm_buildForm($formName, &$form) {
     return;
   }
   // Add Settings Template.
-  // For Editing a group, then adding to regions other than html-header
-  // results in duplicate elements.
-  // For Adding a group, the html-header region inserts the template before
-  // CRM.$ is loaded.
-  $region = $form->getAction() == CRM_Core_Action::ADD ? 'page-footer' : 'html-header';
+  $region = 'page-footer';
 
   CRM_Core_Region::instance($region)->add(
     ['template' => 'CRM/Group/MauticSettings.tpl']);

--- a/sql/mauticwebhook_install.sql
+++ b/sql/mauticwebhook_install.sql
@@ -40,7 +40,7 @@ CREATE TABLE `civicrm_mauticwebhook` (
                                        `activity_id` int unsigned COMMENT 'FK to Contact',
                                        `contact_id` int unsigned COMMENT 'FK to Contact',
                                        `created_date` timestamp DEFAULT CURRENT_TIMESTAMP COMMENT 'When the webhook was first received by CiviCRM',
-                                       `processed_date` timestamp DEFAULT NULL COMMENT 'Has this webhook been processed in CiviCRM',
+                                       `processed_date` timestamp NULL DEFAULT NULL COMMENT 'Has this webhook been processed in CiviCRM',
                                        PRIMARY KEY (`id`)
 )
 ENGINE=InnoDB;

--- a/templates/CRM/Group/MauticSettings.tpl
+++ b/templates/CRM/Group/MauticSettings.tpl
@@ -18,30 +18,66 @@
 {literal}
 <script>
   (function($) {
-    var mautic_settings = $('#mautic_settings').html();
-    var mautic_segment_id = parseInt($("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").val());
-    mautic_settings = mautic_settings.replace("<tbody>", "");
-    mautic_settings = mautic_settings.replace("</tbody>", "");
-    $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").parent().parent().after(mautic_settings);
-    $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").parent().parent().hide();
-    $("#mautic_segment_tr").hide();
-
-    // action on selection of integration radio options
-    var toggleRows = $('.show-enabled');
-    $("input:radio[name=mautic_integration_option]").change(function() {
-      if (parseInt($(this).val()) === 1) {
-        $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").val(mautic_segment_id);
-        toggleRows.show();
-      } else {
-        toggleRows.hide();
-        mautic_segment_id = $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").val();
-        $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").val('');
+    var mauticSettingsInitialized = false;
+    debugger
+    
+    // Function to initialize Mautic settings when the custom field is available
+    function initializeMauticSettings() {
+      // Prevent multiple initializations
+      if (mauticSettingsInitialized) {
+        return;
       }
-    }).filter(':checked').trigger('change');
+      
+      var $customField = $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']");
+      
+      if ($customField.length === 0) {
+        // Custom field not yet loaded, check again later
+        setTimeout(initializeMauticSettings, 100);
+        return;
+      }
 
-    $("#mautic_segment").change(function() {
-      var segment_id = parseInt($("#mautic_segment :selected").val());
-      $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").val(segment_id);
+      
+      var mautic_settings = $('#mautic_settings').html();
+      var mautic_segment_id = parseInt($customField.val());
+
+      mautic_settings = mautic_settings.replace("<tbody>", "");
+      mautic_settings = mautic_settings.replace("</tbody>", "");
+      $customField.parent().parent().after(mautic_settings);
+      $customField.parent().parent().hide();
+      $("#mautic_segment_tr").hide();
+      
+      // Mark as initialized
+      mauticSettingsInitialized = true;
+
+      // action on selection of integration radio options
+      var toggleRows = $('.show-enabled');
+      $("input:radio[name=mautic_integration_option]").change(function() {
+        if (parseInt($(this).val()) === 1) {
+          $customField.val(mautic_segment_id);
+          toggleRows.show();
+        } else {
+          toggleRows.hide();
+          mautic_segment_id = $customField.val();
+          $customField.val('');
+        }
+      }).filter(':checked').trigger('change');
+
+      $("#mautic_segment").change(function() {
+        var segment_id = parseInt($("#mautic_segment :selected").val());
+        $customField.val(segment_id);
+      });
+    }
+    
+    // Start the initialization process
+    CRM.$(document).ready(function() {
+      initializeMauticSettings();
+    });
+    
+    // Also listen for CiviCRM's custom AJAX events in case the field is loaded later
+    CRM.$(document).on('crmLoad', function(event) {
+      if ($(event.target).find("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").length > 0) {
+        initializeMauticSettings();
+      }
     });
   }(CRM.$));
 


### PR DESCRIPTION
## Overview

On the latest CiviCRM versions (tested on 5.75+) the custom group fields on a form are displayed on a page via AJAX, so they cannot be accessed immediately when a page loads. This PR fixes this timing issue and also improves extension lifecycle management.

The changes are:
  - Fix JavaScript timing issue in MauticSettings.tpl where custom fields were accessed before AJAX load
  - Add event_data.xml installation to postInstall() for new installations
  - Implement a comprehensive onUninstall() method to remove all custom groups and artefacts for smooth uninstall and reinstall.

 