### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Mautic/Contact/FieldMapping.php
+++ b/CRM/Mautic/Contact/FieldMapping.php
@@ -377,7 +377,7 @@ class CRM_Mautic_Contact_FieldMapping {
    *   The Mautic contact params that were sent by Mautic
    *
    * @return int|null
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public static function createCommsPrefsActivity($civicrmContact, $mauticContact) {
     foreach (self::$commsPrefFields as $key) {

--- a/CRM/Mautic/Webhook/Handler.php
+++ b/CRM/Mautic/Webhook/Handler.php
@@ -27,7 +27,7 @@ class CRM_Mautic_Webhook_Handler extends CRM_Mautic_Webhook {
   /**
    * @param array $webhook
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function processEvent($webhook) {
     $data = json_decode($webhook['data'], TRUE);
@@ -98,7 +98,7 @@ class CRM_Mautic_Webhook_Handler extends CRM_Mautic_Webhook {
    *
    * @param string $rawData
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function process($rawData) {
     $data = json_decode($rawData, TRUE);
@@ -129,7 +129,7 @@ class CRM_Mautic_Webhook_Handler extends CRM_Mautic_Webhook {
    * @param int $mauticWebhookEntityID
    *
    * @return int|null
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   public function createActivity($trigger, $contactID, $mauticWebhookEntityID) {
     // Source contact must exist. For a post_delete webhook that contact ID might not so we use the logged in user.

--- a/api/v3/Mautic/Getchecksum.php
+++ b/api/v3/Mautic/Getchecksum.php
@@ -23,7 +23,7 @@ function _civicrm_api3_mautic_Getchecksum_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mautic_Getchecksum($params) {
 
@@ -48,6 +48,6 @@ function civicrm_api3_mautic_Getchecksum($params) {
     return civicrm_api3_create_success($returnValues, $params, 'Mautic', 'Getchecksum');
   }
   else {
-    throw new API_Exception('The id parameter is required');
+    throw new CRM_Core_Exception('The id parameter is required');
   }
 }

--- a/api/v3/Mautic/Pushsync.php
+++ b/api/v3/Mautic/Pushsync.php
@@ -19,7 +19,7 @@ function _civicrm_api3_mautic_Pushsync_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mautic_Pushsync($params) {
   // Do push from CiviCRM

--- a/api/v3/MauticWebhook.php
+++ b/api/v3/MauticWebhook.php
@@ -18,7 +18,7 @@ function _civicrm_api3_mautic_webhook_create_spec(&$spec) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mautic_webhook_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -29,7 +29,7 @@ function civicrm_api3_mautic_webhook_create($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mautic_webhook_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -40,7 +40,7 @@ function civicrm_api3_mautic_webhook_delete($params) {
  *
  * @param array $params
  * @return array API result descriptor
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_mautic_webhook_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.