### PR TITLE
Fix Compatibility With Latest Version Of Civirules Extension

### DIFF
--- a/CRM/Civirules/Trigger/MauticWebhook.php
+++ b/CRM/Civirules/Trigger/MauticWebhook.php
@@ -44,7 +44,7 @@ class CRM_Civirules_Trigger_MauticWebhook extends CRM_Civirules_Trigger_Post {
    *
    * @return string
    */
-  public function getTriggerDescription() {
+  public function getTriggerDescription(): string {
     return E::ts('Mautic Webhook processed');
   }
 


### PR DESCRIPTION
## Overview
This PR fixes a bug that caused several pages to blank out, it was caused due to incompatibility with [this](https://lab.civicrm.org/extensions/civirules/-/commit/6f53b886251a030c88a23231a1725705b9043751) change introduced in civirules few months back.