### PR TITLE
CUKMM-78: Refresh Mautic Segment Name In Group List

### DIFF
--- a/mautic.php
+++ b/mautic.php
@@ -47,6 +47,7 @@ function mautic_civicrm_buildForm($formName, &$form) {
   if ($form->isSubmitted()) {
     return;
   }
+
   // Add Settings Template.
   $region = 'page-footer';
 
@@ -196,6 +197,13 @@ function mautic_civicrm_pageRun(&$page) {
 
       $js_safe_object['id' . $group_id] = $val;
     }
+
+    if (CRM_Utils_Request::retrieve('mautic_groups_refresh', 'Boolean')) {
+      header('Content-Type: application/json');
+      echo json_encode($js_safe_object);
+      CRM_Utils_System::civiExit();
+    }
+
     $page->assign('mautic_groups', json_encode($js_safe_object));
   }
 }

--- a/templates/CRM/Group/MauticSettings.tpl
+++ b/templates/CRM/Group/MauticSettings.tpl
@@ -19,24 +19,23 @@
 <script>
   (function($) {
     var mauticSettingsInitialized = false;
-    debugger
-    
+
     // Function to initialize Mautic settings when the custom field is available
     function initializeMauticSettings() {
       // Prevent multiple initializations
       if (mauticSettingsInitialized) {
         return;
       }
-      
+
       var $customField = $("input[data-crm-custom='Mautic_Settings:Mautic_Segment']");
-      
+
       if ($customField.length === 0) {
         // Custom field not yet loaded, check again later
         setTimeout(initializeMauticSettings, 100);
         return;
       }
 
-      
+
       var mautic_settings = $('#mautic_settings').html();
       var mautic_segment_id = parseInt($customField.val());
 
@@ -45,7 +44,7 @@
       $customField.parent().parent().after(mautic_settings);
       $customField.parent().parent().hide();
       $("#mautic_segment_tr").hide();
-      
+
       // Mark as initialized
       mauticSettingsInitialized = true;
 
@@ -67,12 +66,12 @@
         $customField.val(segment_id);
       });
     }
-    
+
     // Start the initialization process
     CRM.$(document).ready(function() {
       initializeMauticSettings();
     });
-    
+
     // Also listen for CiviCRM's custom AJAX events in case the field is loaded later
     CRM.$(document).on('crmLoad', function(event) {
       if ($(event.target).find("input[data-crm-custom='Mautic_Settings:Mautic_Segment']").length > 0) {

--- a/templates/CRM/Group/Page/Group.extra.tpl
+++ b/templates/CRM/Group/Page/Group.extra.tpl
@@ -1,7 +1,10 @@
 <script>
 {if $mautic_groups}
 var mautic_groups = {$mautic_groups};
+{else}
+var mautic_groups = {};
 {/if}
+
 {literal}
 function mauticGroupsPageAlter() {
   if (!mautic_groups) {
@@ -12,30 +15,42 @@ function mauticGroupsPageAlter() {
     cj('table.crm-group-selector thead th.crm-group-visibility').after(
        '<th class="crm-mautic">Mautic Sync</th>');
   }
-  
+
   var rows = cj('table.crm-group-selector tbody tr');
   rows.each(function() {
     var row = cj(this);
-    var group_id_index = 'id' + row.data('id');
-    var mautic_td = cj('<td class="crm-mautic" />');
+    var group_id = row.data('id');
+    if (!group_id) return;
+    var group_id_index = 'id' + group_id;
+
+    var mautic_td = row.find('td.crm-mautic');
+    if (mautic_td.length < 1) {
+      mautic_td = cj('<td class="crm-mautic" />');
+      row.find('td.crm-group-visibility').after(mautic_td);
+    }
+
     if (mautic_groups[group_id_index]) {
       mautic_td.text(mautic_groups[group_id_index]);
+    } else {
+      mautic_td.text('');
     }
-    row.find('td.crm-group-visibility').after(mautic_td);
   });
 }
 {/literal}
+
 {if $action eq 16}
 {* action 16 is VIEW, i.e. the Manage Groups page.*}
 {literal}
   cj('table.crm-group-selector').on( 'draw.dt', function () {
     mauticGroupsPageAlter();
   });
+
+  cj(document).on('crmFormSuccess', function() {
+    cj.getJSON(CRM.url('civicrm/group', {reset: 1, snippet: 4, mautic_groups_refresh: 1}), function(data) {
+       mautic_groups = data;
+       mauticGroupsPageAlter();
+    }).fail(function(jqXHR, textStatus, errorThrown) {console.warn("getJSON request failed! Status:", textStatus, "Error:", errorThrown)});
+  });
 {/literal}
 {/if}
 </script>
-
-{if $action eq 2}
-    {* action 16 is EDIT a group *}
-    {include file="CRM/Group/MauticSettings.tpl"}
-{/if}


### PR DESCRIPTION
## Overview
Currently on manage group screen if a user edits the group and changes the mautic segment for syncing and saves the group the edit modal closes but the change in mautic segment is not displayed until user refreshes the page. This Pr fixes this issue and now the mautic segment chnage is displayed immediately as soon as the edit modal closes.