### PR TITLE
Fix tag setting

### DIFF
--- a/templates/CRM/Mautic/Form/Settings.tpl
+++ b/templates/CRM/Mautic/Form/Settings.tpl
@@ -47,8 +47,10 @@
       }
     }).trigger('change');
     $('[name=mautic_sync_tag_method]').change(function() {
+      if (!$(this).is(':checked')) {
+        return;
+      }
       var show = $(this).val() == 'sync_tag_children';
-      console.log(show);
       $('.wrapper-mautic_sync_tag_parent').toggle(show);
     }).trigger('change');
 


### PR DESCRIPTION
## Overview
Currently on the settings page when user selects a tag after choosing **Restrict tag synchronization to a tag-set** from T**ag Synchronization** and saves the form the setting is saved correctly but when user opens the settings page again the tag dropdown is not visible anymore although the **Restrict tag synchronization to a tag-set** option is selected. This pr fixes this issue so that the tag dropdown is always visible if **Restrict tag synchronization to a tag-set** is selected 