### PR TITLE
Improve DNC Handling

### DIFF
--- a/CRM/Mautic/Sync.php
+++ b/CRM/Mautic/Sync.php
@@ -1427,8 +1427,14 @@ class CRM_Mautic_Sync {
       $tagHelper->setData($civi_details['contact'], $mautic_details['contact']);
       $params['tags'] = $tagHelper->getCiviTagsForMautic($civi_details['civicrm_contact_id'], TRUE);
     }
-    // Comms Prefs.
-    $params = CRM_Mautic_Contact_FieldMapping::commsPrefsCiviToMautic($civi_details['contact'], $params);
+
+    $civiDoNotContact = (int) (!empty($civi_details['contact']['is_opt_out']) || !empty($civi_details['contact']['do_not_email']));
+    $mauticDoNotContact = (int) (isset($mautic_details['contact']['doNotContact'][0]['id']));
+
+    if ($civiDoNotContact !== $mauticDoNotContact) {
+      // Comms Prefs.
+      $params = CRM_Mautic_Contact_FieldMapping::commsPrefsCiviToMautic($civi_details['contact'], $params);
+    }
 
     // The contact exists in mautic but is not a member of the group.
     // This will just need adding to the group.


### PR DESCRIPTION
## Overview
In [this](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mautic/pull/54) PR we added the syncing of DNC between civi and mautic however it was a bit inefficient as it executed one api call for dnc update per contact edit regardless of the fact that dnc needs updation or not, this PR improves the efficiency of the dnc syncing so that api call to update dnc is only made to mautic if dnc is different between civi and mautic.