### PR TITLE
Fix Mautic Contact ID Display

### DIFF
--- a/mautic.php
+++ b/mautic.php
@@ -271,8 +271,36 @@ function mautic_civicrm_fieldOptions($entity, $field, &$options, $params) {
  *
  */
 function mautic_civicrm_alterCustomFieldDisplayValue(&$displayValue, $value, $entityId, $fieldInfo) {
-  if ($fieldInfo['name'] == 'Mautic_Contact_ID') {
+  if ($fieldInfo['name'] == 'Mautic_Contact_ID' && !empty($value)) {
     $mauticURL = \Civi::settings()->get('mautic_connection_url');
     $displayValue = "<a href='{$mauticURL}/s/contacts/view/{$value}' target='_blank'>$value</a>";
   }
+}
+
+/**
+ * Implements hook_civicrm_alterContent().
+ */
+function mautic_civicrm_alterContent(&$content, $context, $tplName, &$object) {
+  if (empty($content) || strpos($content, '/s/contacts/view/') === FALSE) {
+    return;
+  }
+
+  $mauticURL = \Civi::settings()->get('mautic_connection_url');
+  if (empty($mauticURL)) {
+    return;
+  }
+
+  $escapedURL = preg_quote(htmlspecialchars($mauticURL, ENT_QUOTES), '/');
+  $pattern = '/&lt;a href=(?:&#039;|&quot;)' . $escapedURL
+    . '\/s\/contacts\/view\/(\d+)(?:&#039;|&quot;) target=(?:&#039;|&quot;)_blank(?:&#039;|&quot;)&gt;\d+&lt;\/a&gt;/';
+
+  $content = preg_replace_callback(
+    $pattern,
+    function ($matches) use ($mauticURL) {
+      $id = $matches[1];
+      $href = htmlspecialchars($mauticURL . '/s/contacts/view/' . $id, ENT_QUOTES);
+      return '<a href="' . $href . '" target="_blank" rel="noopener">' . $id . '</a>';
+    },
+    $content
+  );
 }


### PR DESCRIPTION
## Summary

After [this](https://github.com/civicrm/civicrm-core/pull/35143) security PR, the **Mautic Contact ID** custom field on the contact summary page is showing the raw anchor markup as text instead of a clickable link due to the custom field value being escaped now, e.g.:

```
<a href='http://127.0.0.1:9001/s/contacts/view/2' target='_blank'>2</a>
```
## Before
<img width="766" height="124" alt="Screenshot 2026-04-29 at 9 44 34 PM" src="https://github.com/user-attachments/assets/a6fd5815-1f77-4e56-8245-9d533e226d0f" />

## After
<img width="766" height="124" alt="Screenshot 2026-04-29 at 9 47 28 PM" src="https://github.com/user-attachments/assets/a17c5b96-e313-427d-84a6-73c51aa6db79" />


## Fix

Rather than override a CiviCRM core template (which would affect **every** custom field and risk introducing XSS for fields containing user-supplied HTML), we add a tightly-scoped `hook_civicrm_alterContent` implementation. It runs **after** the page is rendered, detects the escaped Mautic link pattern in the output, and converts it back into a real anchor element.

The detection regex is built from the configured `mautic_connection_url`, so it only matches the exact escaped form produced by our hook and won't rewrite anything else on the page.