### PR TITLE
Remove Orphaned Condition

### DIFF
--- a/CRM/Mautic/Upgrader.php
+++ b/CRM/Mautic/Upgrader.php
@@ -161,6 +161,46 @@ class CRM_Mautic_Upgrader extends CRM_Extension_Upgrader_Base {
   }
 
   /**
+   * Remove the mautic_contact_matches_civicrm CiviRules condition. Its class
+   * (CRM_Civirules_Condition_MauticContactMatches) was never implemented, so
+   * any use of it would be fatal.
+   *
+   * @return bool
+   */
+  public function upgrade_4209() {
+    $this->ctx->log->info('Removing orphaned CiviRules condition mautic_contact_matches_civicrm (class CRM_Civirules_Condition_MauticContactMatches does not exist).');
+    try {
+      if (CRM_Core_DAO::checkTableExists('civirule_condition')) {
+        $conditionId = CRM_Core_DAO::singleValueQuery(
+          "SELECT id FROM civirule_condition WHERE name = %1 OR class_name = %2",
+          [
+            1 => ['mautic_contact_matches_civicrm', 'String'],
+            2 => ['CRM_Civirules_Condition_MauticContactMatches', 'String'],
+          ]
+        );
+        if ($conditionId) {
+          if (CRM_Core_DAO::checkTableExists('civirule_rule_condition')) {
+            CRM_Core_DAO::executeQuery(
+              "DELETE FROM civirule_rule_condition WHERE condition_id = %1",
+              [1 => [$conditionId, 'Integer']]
+            );
+          }
+          CRM_Core_DAO::executeQuery(
+            "DELETE FROM civirule_condition WHERE id = %1",
+            [1 => [$conditionId, 'Integer']]
+          );
+        }
+      }
+
+      return TRUE;
+    }
+    catch (Throwable $e) {
+      $this->ctx->log->err('upgrade_4209 failed: ' . $e->getMessage());
+      return FALSE;
+    }
+  }
+
+  /**
    * Uninstall - remove custom data and other artifacts.
    */
   public function onUninstall()

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ It currently provides:
  - A CiviRules Trigger to handle Mautic webhooks.
  - CiviRules Conditions:
    - Mautic Webhook type
-   - Mautic Contact matches a CiviCRM Contact
    - Mautic Contact has a tag
    - Mautic Contact field has a particular value
    - Event is linked to a Mautic Segment

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,6 @@ It currently provides:
 - A CiviRules Trigger to handle Mautic webhooks.
 - CiviRules Conditions:
   - Mautic Webhook type
-  - Mautic Contact matches a CiviCRM Contact
   - Mautic Contact has a tag
   - Mautic Contact field has a particular value
   - Event is linked to a Mautic Segment
@@ -191,14 +190,6 @@ Note, if you install CiviRules after the Mautic extension, go to *Administer > M
 Use this condition to select which Mautic trigger event types to process in the rule.
 Currently you will probably want to respond only to contact-related events.
 For example the *Contact Identified Event* will provide data on new Mautic contacts, whereas a *Contact Updated Event* will provide data on changes to existing contacts.
-
-### Condition: Mautic Contact matches a CiviCRM Contact
-Use this condition if you want to have different set of actions if the Mautic event concerns a contact that doesn't match an existing contact in CiviCRM.
-If you just want to sync the contact and don't need to treat new contacts differently from existing ones then you don't need to use this condition.
-The action to create contacts from Mautic can add or update contacts accordingly.
-
-When matching contacts, the extension checks for reference to the contact id on a custom field (2-way).
-If a valid reference isn't found, it falls back to a dedupe rule (configured in the main extensions settings).
 
 ### Other Conditions
 The other conditions are based on various properties of the incoming Mautic contact.

--- a/sql/civirules/conditions.json
+++ b/sql/civirules/conditions.json
@@ -1,7 +1,6 @@
 [
   {"name":"mautic_webhook_of_type","label":"Mautic Webhook is (not) one of Type(s)","class_name":"CRM_Civirules_Condition_MauticWebhookType"},
   {"name":"mautic_event_linked_to_segment","label":"Event is linked to a Mautic Segment","class_name":"CRM_Civirules_Condition_EventMauticSegment"},
-  {"name":"mautic_contact_matches_civicrm","label":"Mautic Contact matches a CiviCRM Contact","class_name":"CRM_Civirules_Condition_MauticContactMatches"},
   {"name":"mautic_contact_has_tag","label":"Mautic Contact has a tag","class_name":"CRM_Civirules_Condition_MauticContactHasTag"},
   {"name":"mautic_contact_field_value","label":"Mautic Contact field has value","class_name":"CRM_Civirules_Condition_MauticContactFieldValue"}
 ]


### PR DESCRIPTION
## Overview

The Mautic extension declares a CiviRules condition `mautic_contact_matches_civicrm` in `sql/civirules/conditions.json`, but its class `CRM_Civirules_Condition_MauticContactMatches` was never implemented. Any rule using this condition would result in a fatal error. This PR removes the orphaned condition declaration and cleans it up from the database.

## Changes

- **`sql/civirules/conditions.json`**: Removed the `mautic_contact_matches_civicrm` condition entry, so it is no longer inserted on fresh installs or when CiviRules definitions are re-synced.
- **`CRM/Mautic/Upgrader.php`**: Added `upgrade_4209()` which removes the condition from existing installations:
  - Looks up the condition in `civirule_condition` by name or class name.
  - Deletes any `civirule_rule_condition` rows referencing it (rules using it were already broken, since the class does not exist).
  - Deletes the condition itself.
  - All queries are parameterized and guarded by table-existence checks, so the upgrade is safe when CiviRules is not installed.

## How to test

1. On an existing site, confirm the condition exists:
```sql
   SELECT * FROM civirule_condition WHERE name = 'mautic_contact_matches_civicrm';
```
2. Run the extension upgrade (`cv upgrade:db` or via the UI).
3. Confirm the condition and any `civirule_rule_condition` references are gone.
4. Verify the remaining Mautic CiviRules conditions still appear when creating a rule.